### PR TITLE
Correctly set original volume after announcement

### DIFF
--- a/lib/persistentPlayer.js
+++ b/lib/persistentPlayer.js
@@ -296,7 +296,7 @@ module.exports = function (logClass) {
                   that.removeListener(that.EVENT_STATUS, announcementCheckStatus);
                   //Reset original volume if required
                   if (urlOptions.volume) {
-                    that._client.setVolumePromise(urlOptions.volume);
+                    that._client.setVolumePromise(currentVolume);
                   }
                   resolve(playUrlPromise);
                 }


### PR DESCRIPTION
Currently, `playAccouncement` does not correctly reset to the original volume if you pass in a `volume` option and there was nothing already playing.

This fixes the issue.