### PR TITLE
Fix incorrect reference to that._playlist

### DIFF
--- a/lib/persistentPlayer.js
+++ b/lib/persistentPlayer.js
@@ -146,7 +146,7 @@ module.exports = function (logClass) {
     getPlaylist(id) {
       let that = this;
       if (that._playlist)
-        return that._playlis.getAll;
+        return that._playlist.getAll;
       else
         return undefined;
     }

--- a/lib/persistentPlayer.js
+++ b/lib/persistentPlayer.js
@@ -146,7 +146,7 @@ module.exports = function (logClass) {
     getPlaylist(id) {
       let that = this;
       if (that._playlist)
-        return that._playlist.getAll;
+        return that._playlist.getAll();
       else
         return undefined;
     }


### PR DESCRIPTION
This fixes a hard crash when calling `getPlaylist()`